### PR TITLE
Refix bug with artifact weapon item level

### DIFF
--- a/InspectItemLevel.lua
+++ b/InspectItemLevel.lua
@@ -94,7 +94,6 @@ function ILvlFrame:GetItemLvL(unit)
 	end
 	if(iterate == 14) then
 		local artilvl = self:GetArtifactWeaponLevel(unit)
-		print("Artifact weapon is "..artilvl)
 		total = total + (artilvl * 2)
 	end
 	

--- a/InspectItemLevel.lua
+++ b/InspectItemLevel.lua
@@ -114,14 +114,3 @@ function ILvlFrame:ScanForItemLevel(itemLink)
 	tt:Hide();
 	return itemLevel
 end
-
-
-
-
-
-
-
-
-
-
-

--- a/InspectItemLevel.lua
+++ b/InspectItemLevel.lua
@@ -1,4 +1,4 @@
---version 1.1.0
+--version 1.3.0
 local Slots = {
 	"Head","Neck","Shoulder","Back","Chest","Wrist",
 	"Hands","Waist","Legs","Feet","Finger0","Finger1",

--- a/InspectItemLevel.lua
+++ b/InspectItemLevel.lua
@@ -9,7 +9,6 @@ local InspectCache = {}
 
 local ILvlFrame = CreateFrame("Frame", "IlvlFrame")
 ILvlFrame:RegisterEvent("INSPECT_READY")
-ILvlFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
 
 ILvlFrame:ClearAllPoints()
 ILvlFrame:SetHeight(300)
@@ -54,10 +53,6 @@ function ILvlFrame:INSPECT_READY(event, GUID)
 	end
 end
 
-function ILvlFrame:PLAYER_TARGET_CHANGED()
-	isCalculatingIlevel = false;
-end
-
 function ILvlFrame:GetItemLvL(unit)
 	local total = 0;
 	for i = 1, #Slots do
@@ -69,27 +64,22 @@ function ILvlFrame:GetItemLvL(unit)
 			end
 		end
 	end
-	local mainHandSkipped = false
+	local mainHandilvl, secondHandilvl = 0, 0;
 	local itemLink = GetInventoryItemLink(unit, GetInventorySlotInfo("MainHandSlot"));
 	if (itemLink ~= nil) then
-		local itemLevel = self:ScanForItemLevel(itemLink);
-		if(itemLevel == 750) then
-			mainHandSkipped = true
-		else
-			total = total + itemLevel + itemLevel
-		end
+		mainHandilvl = self:ScanForItemLevel(itemLink);
 	end
 	local itemLink = GetInventoryItemLink(unit, GetInventorySlotInfo("SecondaryHandSlot"));
 	if (itemLink ~= nil) then
-		local itemLevel = self:ScanForItemLevel(itemLink);
-		if(itemLevel == 750) then
-			if(mainHandSkipped) then
-				total = total + itemLevel + itemLevel
-				print("Both weapons are 750 ilvl. Bug?")
-			end
-		else
-			total = total + itemLevel + itemLevel
-		end
+		secondHandilvl = self:ScanForItemLevel(itemLink);
+	end
+	if(mainHandilvl > secondHandilvl) then
+		total = total + (mainHandilvl * 2)
+	else
+		total = total + (secondHandilvl * 2)
+	end
+	if(mainHandilvl == secondHandilvl and mainHandilvl == 750) then
+		print("Both weapons are ilvl 750. Bug?")
 	end
 	if(total < 1) then
 		return


### PR DESCRIPTION
I tried your improved code but the bug with artifact weapons and their applied artifacts was back. Also reinspecting did not fix the bug with both weapons randomly being 750.

(I guess this is a bug on Blizzard's side? Other addons have this too.)

I also fixed cache usage to only occur when no fresh data could be fetched. Blizzard's own UI fetches inspect data with every inspect anyways and we're only hooking off their data.